### PR TITLE
added '-q' parameter to aptitude

### DIFF
--- a/tools/pi-appliance-update
+++ b/tools/pi-appliance-update
@@ -34,14 +34,14 @@ function do_update_security {
 	log "### Downloading packages."
 	aptitude update >> $LOGFILE
 	log "### Starting update."
-	aptitude safe-upgrade -o Aptitude::Delete-Unused=${CLEAN} --assume-yes --target-release `lsb_release -cs`-security >> $LOGFILE
+	aptitude -q safe-upgrade -o Aptitude::Delete-Unused=${CLEAN} --assume-yes --target-release `lsb_release -cs`-security >> $LOGFILE
 }
 
 function do_update_updates {
 	log "### Downloading packages."
 	aptitude update >> $LOGFILE
 	log "### Starting update."
-	aptitude full-upgrade -o Aptitude::Delete-Unused=${CLEAN} --assume-yes --target-release `lsb_release -cs`-updates >> $LOGFILE
+	aptitude -q full-upgrade -o Aptitude::Delete-Unused=${CLEAN} --assume-yes --target-release `lsb_release -cs`-updates >> $LOGFILE
 }
 
 


### PR DESCRIPTION
The '-q' parameter suppresses the output of  progress indicators (i.e. download of packages) which would clutter the log file.